### PR TITLE
Support vite dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ const view = new EditorView(editor, {
 });
 ```
 
+Example use with [TipTap editor](https://tiptap.dev):
+```ts
+import codemark from 'prosemirror-codemark';
+import 'codemark/dist/codemark.css';
+
+const codemarkPlugin = Extension.create({
+  name: "codemarkPlugin",
+  addProseMirrorPlugins() {
+    return codemark({ markType: this.editor.schema.marks.code });
+  },
+});
+
+this.editor = new Editor({
+  extensions: [StarterKit, codemarkPlugin],
+  content: `this is <code>code</code> test`,
+});
+```
+
 The styles are necessary to show the `.fake-cursor`, they are simple if you want to [override them](./src/codemark.css). It does not provide styles for the `code` specifically. The plugin visually works best if the code mark has a border and a different color than the main text.
 
 ## Why

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,7 +1,7 @@
-import { MarkType } from 'prosemirror-model';
+import type { MarkType } from 'prosemirror-model';
 import { EditorState, Plugin, TextSelection, Transaction } from 'prosemirror-state';
-import { EditorView } from 'prosemirror-view';
-import { CodemarkState, CursorMetaTr } from './types';
+import type { EditorView } from 'prosemirror-view';
+import type { CodemarkState, CursorMetaTr } from './types';
 import { MAX_MATCH, safeResolve } from './utils';
 
 export function stepOutsideNextTrAndPass(

--- a/src/inputRules.ts
+++ b/src/inputRules.ts
@@ -1,7 +1,8 @@
-import { MarkType } from 'prosemirror-model';
-import { Plugin, PluginSpec, TextSelection, Transaction } from 'prosemirror-state';
-import { EditorView } from 'prosemirror-view';
-import { Options } from './types';
+import type { MarkType } from 'prosemirror-model';
+import { Plugin, TextSelection, Transaction } from 'prosemirror-state';
+import type { PluginSpec } from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
+import type { Options } from './types';
 import { getMarkType, MAX_MATCH } from './utils';
 
 type InputRuleState = {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,7 @@
-import { Plugin, PluginSpec } from 'prosemirror-state';
+import { Plugin } from 'prosemirror-state';
+import type { PluginSpec } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
-import { CodemarkState, CursorMetaTr, Options } from './types';
+import type { CodemarkState, CursorMetaTr, Options } from './types';
 import { getMarkType, pluginKey, safeResolve } from './utils';
 import { createInputRule } from './inputRules';
 import {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { MarkType } from 'prosemirror-model';
+import type { MarkType } from 'prosemirror-model';
 
 export type Options = {
   markType?: MarkType;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
-import { MarkType, Node } from 'prosemirror-model';
+import type { MarkType, Node } from 'prosemirror-model';
 import { EditorState, PluginKey } from 'prosemirror-state';
-import { EditorView } from 'prosemirror-view';
-import { Options } from './types';
+import type { EditorView } from 'prosemirror-view';
+import type { Options } from './types';
 
 export const DEFAULT_ID = 'codemark';
 export const MAX_MATCH = 100;


### PR DESCRIPTION
Updated typescript to use `import type` instead of `import` where applicable. Enables project loading and debugging with vite.
Verified demo still builds and runs