### PR TITLE
Add the `no-cursor` class to the editor through `attributes`

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -23,14 +23,6 @@ function toDom(): Node {
 export function getDecorationPlugin(opts?: Options) {
   const plugin: Plugin<CodemarkState> = new Plugin({
     key: pluginKey,
-    view() {
-      return {
-        update: (view) => {
-          const state = plugin.getState(view.state) as CodemarkState;
-          view.dom.classList[state?.active ? 'add' : 'remove']('no-cursor');
-        },
-      };
-    },
     appendTransaction: (trs, oldState, newState) => {
       const prev = plugin.getState(oldState) as CodemarkState;
       const meta = trs[0]?.getMeta(plugin) as CursorMetaTr | null;
@@ -73,6 +65,12 @@ export function getDecorationPlugin(opts?: Options) {
       },
     },
     props: {
+      attributes: (state) => {
+        const { active = false } = plugin.getState(state) ?? {};
+        return {
+          ...(active ? { class: 'no-cursor' } : {}),
+        };
+      },
       decorations: (state) => {
         const { active, side } = plugin.getState(state) ?? {};
         if (!active) return DecorationSet.empty;


### PR DESCRIPTION
Hello there 👋

While adding this awesome plugin to [Twist's](https://twist.com/) new editor (currently in beta), I've come across an issue that I wasn't able to reproduce with a minimal example in a [CodeSandbox](https://codesandbox.io/s/wonderful-bhabha-mpznn9), but it was clearly a problem in our code base.

If you're interested to know more about the issue in particular, please refer to [this discussion](https://discuss.prosemirror.net/t/changing-view-dom-classlist-changes-the-selection/) at discuss.ProseMirror. That's also where I got the solution you see on this PR (provided by Marijn Haverbeke himself), which fixes the issue for me, and doesn't break anything, win-win.

I'm hoping you can merge this soon, and publish a new release of `prosemirror-codemark`.